### PR TITLE
Shard the streaming dataset across DDP ranks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ pre-trained model and  running a finetuning routine on them 🌝.
 
 And finally `scripts/finetune.py` has an example LoRA finetune routine.
 
+## Multi-GPU streaming
+
+When streaming the dataset from HuggingFace under DDP, `train.py` shards the
+stream across ranks with `split_dataset_by_node` so each GPU sees disjoint data
+(otherwise every rank replays the same stream and you get no data-throughput
+scaling), and applies a buffered `shuffle` (size `shuffle_buffer_size`) to the
+training stream.
+
 # Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -260,6 +260,19 @@ if __name__ == "__main__":
         )
         vds_hf = vds_hf.remove_columns("image")
 
+        # Shard the stream across DDP ranks so each GPU sees disjoint data.
+        # Without this every rank iterates the identical stream, so e.g. 8 GPUs
+        # would all train on the same galaxies (no data-throughput scaling).
+        if ddp:
+            from datasets.distributed import split_dataset_by_node
+
+            tds_hf = split_dataset_by_node(
+                tds_hf, rank=ddp_rank, world_size=ddp_world_size
+            )
+            vds_hf = split_dataset_by_node(
+                vds_hf, rank=ddp_rank, world_size=ddp_world_size
+            )
+
     tdl = iter(
         DataLoader(
             tds_hf if use_hf else tds,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
     init_from = "scratch"  # 'scratch' or 'resume'
     use_hf = True  # use the huggingface dataset version of our galz
     stream_hf_dataset = True  # stream the galaxies from huggingface
+    shuffle_buffer_size = 1000  # buffered shuffle size for the streaming train set
     # data
     gradient_accumulation_steps = 5 * 8  # used to simulate larger batch sizes
     batch_size = 16  # if gradient_accumulation_steps > 1, this is the micro-batch size
@@ -271,6 +272,11 @@ if __name__ == "__main__":
             )
             vds_hf = split_dataset_by_node(
                 vds_hf, rank=ddp_rank, world_size=ddp_world_size
+            )
+        # Buffered shuffle of the (otherwise in-order) streaming training set.
+        if stream_hf_dataset:
+            tds_hf = tds_hf.shuffle(
+                seed=1337 + seed_offset, buffer_size=shuffle_buffer_size
             )
 
     tdl = iter(


### PR DESCRIPTION
## Shard the streaming dataset across DDP ranks

The streaming HuggingFace path never sharded across DDP processes, so **every rank iterated the identical stream in the same order** — an N-GPU run trained N times on the same galaxies (compute scaling, but no data-throughput scaling).

This adds:
- `split_dataset_by_node(rank, world_size)` on the train and val streams when running under DDP, so each GPU sees disjoint data;
- a buffered `.shuffle()` of the (otherwise in-order) training stream, with a configurable `shuffle_buffer_size`.

### Commits
- `fix(train)`: shard the streaming HF dataset across DDP ranks
- `feat(train)`: buffered shuffle for the streaming training set
- `docs`: README note

### Testing
Verified `split_dataset_by_node` produces disjoint shards whose union is the full dataset across ranks; `train.py` compiles.

### Notes
One of three independent PRs (BERT-style MAE, this, step checkpointing). Touches `train.py` only.
