### PR TITLE
Step-based checkpointing (log/even/manual schedules)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ results in these papers, and `scripts/train.py` for an example boilerplate
 script for pre-training your own AstroPT. `config` contains example user
 configurations for pre-training.
 
+AstroPT trains for roughly one epoch, so `train.py` can save intermediate
+checkpoints by step count: set `num_checkpoints=N` to save `N` snapshots across
+`[0, max_iters]` (always including the first/random-init and last/final step),
+with `checkpoint_schedule` one of `"log"` (default; geometric, dense early —
+good for probing how representations emerge over training), `"even"` (uniform),
+or `"manual"` (use the explicit `checkpoint_steps` list, e.g.
+`--checkpoint_steps=[0,512,4096,30000]`). This is independent of the best-val
+`ckpt.pt`; each checkpoint also stores optimizer state, so budget disk
+accordingly.
+
 `scripts/linear_probe.py` has an example script for inferring embeddings from a 
 pre-trained model and  running a finetuning routine on them 🌝.
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -491,6 +491,20 @@ if __name__ == "__main__":
     local_iter_num = 0  # number of iterations in the lifetime of this process
     raw_model = model.module if ddp else model  # unwrap DDP container if needed
     running_mfu = -1.0
+
+    def save_checkpoint(filename):
+        checkpoint = {
+            "model": raw_model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+            "model_args": model_args,
+            "iter_num": iter_num,
+            "best_val_loss": best_val_loss,
+            "config": config,
+            "modality_registry": modality_registry,
+        }
+        torch.save(checkpoint, os.path.join(out_dir, filename))
+        if master_process:
+            print(f"saving checkpoint to {os.path.join(out_dir, filename)}")
     if log_emissions and master_process:
         tracker = EmissionsTracker(
             output_dir=out_dir,
@@ -568,24 +582,10 @@ if __name__ == "__main__":
             if val_loss < best_val_loss or always_save_checkpoint:
                 best_val_loss = val_loss
                 if iter_num > 0:
-                    model_state = raw_model.state_dict()
-                    checkpoint = {
-                        "model": model_state,
-                        "optimizer": optimizer.state_dict(),
-                        "model_args": model_args,
-                        "iter_num": iter_num,
-                        "best_val_loss": best_val_loss,
-                        "config": config,
-                        "modality_registry": modality_registry,
-                    }
-                    if master_process:
-                        print(f"saving checkpoint to {out_dir}")
                     if always_save_checkpoint:
-                        torch.save(
-                            checkpoint, os.path.join(out_dir, f"{iter_num:06d}_ckpt.pt")
-                        )
+                        save_checkpoint(f"{iter_num:06d}_ckpt.pt")
                     else:
-                        torch.save(checkpoint, os.path.join(out_dir, "ckpt.pt"))
+                        save_checkpoint("ckpt.pt")
         if iter_num == 0 and eval_only:
             break
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -91,6 +91,13 @@ if __name__ == "__main__":
     always_save_checkpoint = (
         False  # if True, always save a checkpoint at each checkpoint_interval
     )
+    # save num_checkpoints checkpoints across the run (0 disables), always
+    # including the first (step 0) and last (max_iters) step. checkpoint_schedule
+    # is "log" (geometric, dense early), "even" (uniform), or "manual" (use the
+    # explicit checkpoint_steps list).
+    num_checkpoints = 0
+    checkpoint_schedule = "log"
+    checkpoint_steps = []  # explicit iters, used when checkpoint_schedule == "manual"
     init_from = "scratch"  # 'scratch' or 'resume'
     use_hf = True  # use the huggingface dataset version of our galz
     stream_hf_dataset = True  # stream the galaxies from huggingface
@@ -505,6 +512,29 @@ if __name__ == "__main__":
         torch.save(checkpoint, os.path.join(out_dir, filename))
         if master_process:
             print(f"saving checkpoint to {os.path.join(out_dir, filename)}")
+
+    # step-based checkpoint schedule -> the set of iters to snapshot at. Always
+    # includes the first (random init) and last (final) step. Independent of
+    # eval_interval and the best-val checkpoint.
+    if checkpoint_schedule == "manual" and checkpoint_steps:
+        checkpoint_iters = {int(s) for s in checkpoint_steps}
+    elif num_checkpoints >= 2:
+        if checkpoint_schedule == "even":
+            checkpoint_iters = {
+                int(round(x)) for x in np.linspace(0, max_iters, num_checkpoints)
+            }
+        else:  # "log" (default): geometric spacing, dense early, plus step 0
+            geo = np.geomspace(1, max_iters, num_checkpoints - 1)
+            checkpoint_iters = {0} | {int(round(x)) for x in geo}
+    elif num_checkpoints == 1:
+        checkpoint_iters = {max_iters}
+    else:
+        checkpoint_iters = set()
+    if master_process and checkpoint_iters:
+        print(
+            f"will save {len(checkpoint_iters)} checkpoints at iters "
+            f"{sorted(checkpoint_iters)}"
+        )
     if log_emissions and master_process:
         tracker = EmissionsTracker(
             output_dir=out_dir,
@@ -588,6 +618,10 @@ if __name__ == "__main__":
                         save_checkpoint("ckpt.pt")
         if iter_num == 0 and eval_only:
             break
+
+        # save the scheduled, step-based checkpoints
+        if master_process and iter_num in checkpoint_iters:
+            save_checkpoint(f"{iter_num:06d}_ckpt.pt")
 
         # forward backward update, with optional gradient accumulation to simulate larger batch size
         # and using the GradScaler if data type is float16


### PR DESCRIPTION
## Step-based checkpointing (log / even / manual)

AstroPT trains for roughly one epoch, so intermediate snapshots across the *step* budget are more useful than epoch-based saves (e.g. for probing how representations emerge over training).

Adds `num_checkpoints=N` (0 disables) with `checkpoint_schedule`:
- **`"log"`** (default) — geometric spacing, dense early to capture emergence (Pythia-style);
- **`"even"`** — uniform spacing;
- **`"manual"`** — an explicit `checkpoint_steps` list, e.g. `--checkpoint_steps=[0,512,4096,30000]`.

`log`/`even` always pin the first (random-init) and last (final) step. Snapshots are saved as `NNNNNN_ckpt.pt`, independent of `eval_interval` and the best-val `ckpt.pt`.

### Commits
- `refactor(train)`: extract a `save_checkpoint` helper
- `feat(train)`: step-based checkpointing (log/even/manual)
- `docs`: README note

### Testing
Schedule generation verified across log / even / manual / disabled (always includes first and last for log/even); the `save_checkpoint` refactor preserves the existing best-val path; `train.py` compiles.

### Example
`num_checkpoints=12, max_iters=30000, schedule="log"` → `0, 1, 3, 8, 22, 62, 173, 486, 1361, 3817, 10701, 30000`.

### Notes
One of three independent PRs (BERT-style MAE, DDP stream sharding, this). Touches `train.py` only. Each checkpoint stores optimizer state, so budget disk accordingly.
