### PR TITLE
BERT-style masked-autoencoder (MAE) pretraining objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ Of course we can apply this next-token-prediction task across many modalities du
 
 Check out [our work on Euclid data](https://arxiv.org/abs/2503.15312) for an example, where we chain galaxy image tokens and spectral energy distribution data and pass them into a single, unified AstroPT model.
 
+## Masked autoencoder (MAE) objective
+
+As well as the default autoregressive objective, AstroPT can be pretrained with a
+BERT-style masked autoencoder objective ([He et al. 2021](https://arxiv.org/abs/2111.06377),
+[Devlin et al. 2019](https://arxiv.org/abs/1810.04805)). A fraction of the image
+patches is replaced by a learnable mask token, the full patch sequence is
+processed by the bidirectional encoder, and the masked patches are
+reconstructed. Switch objectives with the `objective` config field (`"ar"` or
+`"mae"`); MAE additionally requires bidirectional attention (`attn_type="full"`)
+and uses AstroPT's existing learned (BERT-style) positional embeddings. See
+`scripts/train_mae.py` and `config/astropt_mae.py` for an example. MAE currently
+supports a single image modality.
+
 # I just want to run it! 🗣️
 
 Okay I hear you! First you need to install the model:

--- a/config/astropt_mae.py
+++ b/config/astropt_mae.py
@@ -1,0 +1,43 @@
+# Example config for BERT-style masked-autoencoder (MAE) pretraining.
+#
+# launch as (e.g. in a tmux session):
+# $ OMP_NUM_THREADS=32 torchrun --standalone --nproc_per_node=8 scripts/train_mae.py config/astropt_mae.py
+#
+# don't forget to $(mkdir logs) !
+
+# params
+n_layer = 12
+n_head = 12
+n_chan = 3
+n_embd = 768
+block_size = 1024
+
+# MAE objective. attn_type must be "full" (bidirectional); the model raises if
+# it is left as the autoregressive default of "causal". BERT-style: mask tokens
+# flow through the full encoder and the masked patches are reconstructed.
+objective = "mae"
+attn_type = "full"
+# fraction of patches replaced by the mask token. BERT uses 0.15 for text;
+# image masked-image-modelling (e.g. SimMIM) typically uses ~0.5-0.6.
+mae_mask_ratio = 0.5
+norm_pix_loss = False
+
+# chinchilla / pythia schedule
+learning_rate = 6e-4
+min_lr = learning_rate / 10
+
+init_from = "scratch"
+batch_size = 16
+gradient_accumulation_steps = 5 * 8
+num_workers = 32
+
+max_iters = 30000
+lr_decay_iters = 27000 * 1.1
+
+# eval stuff
+eval_interval = 1000
+checkpoint_interval = 5000
+eval_iters = 200
+log_interval = 100
+log_via_wandb = True
+out_dir = "logs/astropt_mae"

--- a/scripts/train_mae.py
+++ b/scripts/train_mae.py
@@ -1,0 +1,541 @@
+"""
+BERT-style masked-autoencoder (MAE) pretraining for AstroPT.
+
+Sibling of train.py: instead of the autoregressive next-patch objective it
+trains a BERT-style masked autoencoder. A fraction of image patches is replaced
+by a learnable mask token, the full sequence is processed by the bidirectional
+encoder, and the masked patches are reconstructed. The objective is config-gated
+in the model (objective="mae", attn_type="full"), so the rest of the loop
+mirrors train.py.
+
+To run on a single GPU, example:
+$ python scripts/train_mae.py --batch_size=32 --compile=False
+
+To run with DDP on 4 gpus on 1 node, example:
+$ torchrun --standalone --nproc_per_node=4 scripts/train_mae.py
+"""
+
+import math
+import os
+import time
+from contextlib import nullcontext
+from functools import partial
+
+import einops
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import torch
+from torch.distributed import destroy_process_group, init_process_group
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+try:
+    import wandb
+
+    log_via_wandb = True
+except ImportError:
+    log_via_wandb = False
+try:
+    from codecarbon import EmissionsTracker
+
+    log_emissions = False
+except ImportError:
+    log_emissions = False
+
+from astropt.local_datasets import GalaxyImageDataset
+from astropt.model import GPT, GPTConfig, ModalityConfig, ModalityRegistry
+
+
+def normalise(x, use_hf=False):
+    # HF is in numpy format. Need to change that here if so:
+    if use_hf:
+        x = torch.from_numpy(x).to(torch.float32)
+    std, mean = torch.std_mean(x, dim=1, keepdim=True)
+    x_norm = (x - mean) / (std + 1e-8)
+    return x_norm.to(torch.float16)
+
+
+def data_transforms(use_hf):
+    norm = partial(normalise, use_hf=use_hf)
+    transform = transforms.Compose([transforms.Lambda(norm)])
+    return transform
+
+
+def process_galaxy_wrapper(galdict, func):
+    patch_galaxy = func(np.array(galdict["image"]).swapaxes(0, 2))
+    return {
+        "images": patch_galaxy.to(torch.float),
+        "images_positions": torch.arange(0, len(patch_galaxy), dtype=torch.long),
+    }
+
+
+if __name__ == "__main__":
+    # -----------------------------------------------------------------------------
+    # default config values to test run a ~100M parameter MAE on DESI galaxy imagery
+    out_dir = "logs/astropt_mae0100M"
+    eval_interval = 1000
+    log_interval = 100
+    checkpoint_interval = 5000
+    assert checkpoint_interval % eval_interval == 0
+    eval_iters = 100
+    eval_only = False
+    always_save_checkpoint = False
+    init_from = "scratch"  # 'scratch' or 'resume'
+    use_hf = True
+    stream_hf_dataset = True
+    # data
+    gradient_accumulation_steps = 5 * 8
+    batch_size = 16  # micro-batch size if gradient_accumulation_steps > 1
+    spiral = True
+    block_size = 1024
+    image_size = 256
+    num_workers = 32
+    # astroPT model
+    n_layer = 12
+    n_head = 12
+    n_embd = 768
+    n_chan = 3  # 3 imagery bands: r, i, z for jpeg
+    dropout = 0.0
+    bias = False
+    # MAE objective. MAE needs bidirectional attention, so attn_type must be
+    # "full" (the model raises if it is left as "causal").
+    objective = "mae"
+    attn_type = "full"
+    mae_mask_ratio = 0.15  # fraction of patches replaced by the mask token
+    norm_pix_loss = False  # data pipeline already per-patch normalises
+    # Define modalities configuration. embed_pos=True gives BERT-style learned
+    # absolute positional embeddings.
+    modalities = [
+        ModalityConfig(
+            name="images",
+            input_size=16 * 16 * n_chan,
+            patch_size=16,
+            loss_weight=1.0,
+            embed_pos=True,
+            pos_input_size=1,
+        ),
+    ]
+    modality_registry = ModalityRegistry(modalities)
+    tokeniser = "aim"
+    # adamw optimizer (Chinchilla schedule)
+    learning_rate = 6e-4
+    max_iters = 30000
+    weight_decay = 1e-1
+    beta1 = 0.9
+    beta2 = 0.95
+    grad_clip = 1.0
+    decay_lr = True
+    warmup_iters = 2000
+    lr_decay_iters = 27000 * 1.1
+    min_lr = learning_rate / 10
+    # DDP / system
+    backend = "nccl"
+    device = "cuda"
+    dtype = "bfloat16"
+    compile = True
+    log_via_wandb = False
+    wandb_project = None
+    # -----------------------------------------------------------------------------
+    config_keys = [
+        k
+        for k, v in globals().items()
+        if not k.startswith("_") and isinstance(v, (int, float, bool, str))
+    ]
+    exec(open("src/astropt/configurator.py").read())
+    config = {k: globals()[k] for k in config_keys}
+    # -----------------------------------------------------------------------------
+
+    ddp = int(os.environ.get("RANK", -1)) != -1
+    if ddp:
+        init_process_group(backend=backend)
+        ddp_rank = int(os.environ["RANK"])
+        ddp_local_rank = int(os.environ["LOCAL_RANK"])
+        ddp_world_size = int(os.environ["WORLD_SIZE"])
+        device = f"cuda:{ddp_local_rank}"
+        torch.cuda.set_device(device)
+        master_process = ddp_rank == 0
+        seed_offset = ddp_rank
+        assert gradient_accumulation_steps % torch.cuda.device_count() == 0
+        gradient_accumulation_steps //= torch.cuda.device_count()
+    else:
+        master_process = True
+        seed_offset = 0
+        ddp_world_size = 1
+    tokens_per_iter = (
+        gradient_accumulation_steps
+        * ddp_world_size
+        * batch_size
+        * block_size
+        * len(modalities)
+    )
+    if master_process:
+        print(f"tokens per iteration will be: {tokens_per_iter:,}")
+
+    if master_process:
+        os.makedirs(out_dir, exist_ok=True)
+    torch.manual_seed(1337 + seed_offset)
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    device_type = "cuda" if "cuda" in device else "cpu"
+    ptdtype = {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }[dtype]
+    ctx = (
+        nullcontext()
+        if device_type == "cpu"
+        else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+    )
+
+    # dataset init
+    transforms = {"images": data_transforms(use_hf)}
+    tpaths = None if use_hf else "./data/train.txt"
+    tds = GalaxyImageDataset(
+        paths={"images": tpaths},
+        spiral=spiral,
+        transform=transforms,
+        modality_registry=modality_registry,
+    )
+    vpaths = None if use_hf else "./data/tests.txt"
+    vds = GalaxyImageDataset(
+        paths={"images": vpaths},
+        spiral=spiral,
+        transform=transforms,
+        modality_registry=modality_registry,
+    )
+
+    if use_hf:
+        from datasets import load_dataset
+
+        tds_hf = load_dataset(
+            "Smith42/galaxies",
+            revision="v2.0",
+            split="train",
+            streaming=(True if stream_hf_dataset else False),
+        )
+        tds_hf = tds_hf.select_columns("image").map(
+            partial(process_galaxy_wrapper, func=tds.process_galaxy)
+        )
+        tds_hf = tds_hf.remove_columns("image")
+
+        vds_hf = load_dataset(
+            "Smith42/galaxies",
+            revision="v2.0",
+            split="test",
+            streaming=(True if stream_hf_dataset else False),
+        )
+        vds_hf = vds_hf.select_columns("image").map(
+            partial(process_galaxy_wrapper, func=tds.process_galaxy)
+        )
+        vds_hf = vds_hf.remove_columns("image")
+
+    tdl = iter(
+        DataLoader(
+            tds_hf if use_hf else tds,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            pin_memory=True,
+        )
+    )
+    vdl = iter(
+        DataLoader(
+            vds_hf if use_hf else vds,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            pin_memory=True,
+        )
+    )
+
+    iter_num = 0
+    best_val_loss = 1e9
+
+    model_args = dict(
+        n_layer=n_layer,
+        n_head=n_head,
+        n_embd=n_embd,
+        n_chan=n_chan,
+        block_size=block_size,
+        dropout=dropout,
+        modalities=modalities,
+        attn_type=attn_type,
+        objective=objective,
+        mae_mask_ratio=mae_mask_ratio,
+        norm_pix_loss=norm_pix_loss,
+    )
+
+    if init_from == "scratch":
+        if master_process:
+            print("initializing a new MAE model from scratch")
+        gptconf = GPTConfig(**model_args)
+        model = GPT(gptconf, modality_registry, master_process=master_process)
+    if init_from == "resume":
+        if master_process:
+            print(f"resuming training from {out_dir}")
+        ckpt_path = os.path.join(out_dir, "ckpt.pt")
+        checkpoint = torch.load(ckpt_path, map_location=device, weights_only=False)
+        checkpoint_model_args = checkpoint["model_args"]
+        for k in ["n_layer", "n_head", "n_embd", "block_size"]:
+            model_args[k] = checkpoint_model_args[k]
+        gptconf = GPTConfig(**model_args)
+        model = GPT(gptconf, modality_registry, master_process=master_process)
+        state_dict = checkpoint["model"]
+        unwanted_prefix = "_orig_mod."
+        for k, v in list(state_dict.items()):
+            if k.startswith(unwanted_prefix):
+                state_dict[k[len(unwanted_prefix) :]] = state_dict.pop(k)
+        model.load_state_dict(state_dict)
+        iter_num = checkpoint["iter_num"]
+        best_val_loss = checkpoint["best_val_loss"]
+
+    if log_via_wandb and master_process:
+        if wandb_project is None:
+            wandb.init(
+                project=f"AstroPT-MAE-{model.get_num_params() / 1e6:06.1f}M", config=config
+            )
+        else:
+            wandb.init(project=wandb_project, config=config)
+    with open(f"{out_dir}/hparams.txt", "w") as fi:
+        fi.write(f"AstroPT-MAE-{model.get_num_params() / 1e6:06.1f}M\n")
+        fi.write(f"time: {int(time.time())}\n")
+        for k, v in config.items():
+            fi.write(f"{k}: {v}\n")
+
+    if block_size < model.config.block_size:
+        model.crop_block_size(block_size)
+        model_args["block_size"] = block_size
+    model.to(device)
+
+    scaler = torch.amp.GradScaler(enabled=(dtype == "float16"))
+
+    optimizer = model.configure_optimizers(
+        weight_decay, learning_rate, (beta1, beta2), device_type
+    )
+    if init_from == "resume":
+        optimizer.load_state_dict(checkpoint["optimizer"])
+    checkpoint = None
+
+    if compile:
+        if master_process:
+            print("compiling the model... (takes a ~minute)")
+        unoptimized_model = model
+        model = torch.compile(model)
+
+    if ddp:
+        if master_process:
+            print("Wrapping in DDP")
+        torch._dynamo.config.optimize_ddp = False
+        # single-modality MAE uses every parameter each step, so we do not need
+        # find_unused_parameters
+        model = DDP(model, device_ids=[ddp_local_rank])
+
+    @torch.no_grad()
+    def estimate_loss():
+        out = {}
+        model.eval()
+        for dl, split in zip([tdl, vdl], ["train", "val"]):
+            out[split] = {}
+            losses = torch.zeros(eval_iters)
+            for k in range(eval_iters):
+                B = tds.process_modes(
+                    next(dl), modality_registry, device, objective=objective
+                )
+                with ctx:
+                    logits, loss = model(B["X"], targets=B["Y"])
+                losses[k] = loss.item()
+            out[split]["dummy"] = losses.mean()
+        model.train()
+        return out
+
+    @torch.no_grad()
+    def validate(iter_num, out_dir):
+        """Plot masked-input | reconstruction | target for a batch of galaxies.
+
+        The reconstruction composites the model's predicted patches at the
+        masked positions with the original patches everywhere else.
+        """
+        model.eval()
+        im_patch = modality_registry.get_config("images").patch_size
+        grid = image_size // im_patch
+
+        def to_image(seq):
+            if spiral:
+                seq = torch.stack([vds.antispiralise(s) for s in seq])
+            return einops.rearrange(
+                seq,
+                "b (h w) (p1 p2 c) -> b (h p1) (w p2) c",
+                p1=im_patch,
+                p2=im_patch,
+                h=grid,
+                w=grid,
+            )
+
+        for dl, split in zip([tdl, vdl], ["train", "val"]):
+            f, axs = plt.subplots(8, 3, figsize=(4.5, 12), constrained_layout=True)
+            axs[0, 0].set_title("masked")
+            axs[0, 1].set_title("recon")
+            axs[0, 2].set_title("target")
+            B = vds.process_modes(
+                next(dl), modality_registry, device, objective=objective
+            )
+            with ctx:
+                P, loss = model(B["X"], B["Y"])
+            Yim = B["Y"]["images"].to(device).float()
+            Pim = P["images"].float()
+            mask = P["images_mask"].unsqueeze(-1).float()
+            masked_input = Yim * (1 - mask)
+            recon = Yim * (1 - mask) + Pim * mask
+
+            masked_img = to_image(masked_input).cpu().numpy()
+            recon_img = to_image(recon).cpu().numpy()
+            target_img = to_image(Yim).cpu().numpy()
+
+            for ax, mi, ri, ti in zip(axs, masked_img, recon_img, target_img):
+                ax[0].imshow(np.clip(mi, 0, 1))
+                ax[1].imshow(np.clip(ri, 0, 1))
+                ax[2].imshow(np.clip(ti, 0, 1))
+                for a in ax:
+                    a.axis("off")
+
+            if log_via_wandb:
+                wandb.log(
+                    {
+                        f"{split}_masked": [wandb.Image(np.clip(mi, 0, 1)) for mi in masked_img],
+                        f"{split}_recon": [wandb.Image(np.clip(ri, 0, 1)) for ri in recon_img],
+                        f"{split}_target": [wandb.Image(np.clip(ti, 0, 1)) for ti in target_img],
+                    }
+                )
+
+            f.savefig(
+                os.path.join(out_dir, f"{iter_num:06d}_{split}.jpg"),
+                bbox_inches="tight",
+                pad_inches=0,
+            )
+            plt.close(f)
+        model.train()
+
+    def get_lr(it):
+        if it < warmup_iters:
+            return learning_rate * it / warmup_iters
+        if it > lr_decay_iters:
+            return min_lr
+        decay_ratio = (it - warmup_iters) / (lr_decay_iters - warmup_iters)
+        assert 0 <= decay_ratio <= 1
+        coeff = 0.5 * (1.0 + math.cos(math.pi * decay_ratio))
+        return min_lr + coeff * (learning_rate - min_lr)
+
+    if master_process:
+        print("starting training...")
+    B = tds.process_modes(next(tdl), modality_registry, device, objective=objective)
+    t0 = time.time()
+    dts = []
+    local_iter_num = 0
+    raw_model = model.module if ddp else model
+    running_mfu = -1.0
+    if log_emissions and master_process:
+        tracker = EmissionsTracker(
+            output_dir=out_dir, log_level="error", save_to_file=True, on_csv_write="update"
+        )
+        tracker.start()
+    while True:
+        lr = get_lr(iter_num) if decay_lr else learning_rate
+        for param_group in optimizer.param_groups:
+            param_group["lr"] = lr
+
+        if iter_num % eval_interval == 0 and master_process:
+            validate(iter_num, out_dir)
+            losses = estimate_loss()
+            val_loss = np.mean(list(losses["val"].values()))
+            print(
+                f"iter {iter_num}:\ntrain loss:\n{losses['train']}\nval loss:\n{losses['val']}"
+            )
+            with open(os.path.join(out_dir, "loss.txt"), "a") as fi:
+                if fi.tell() == 0:
+                    train_head_str = ",".join(
+                        map(lambda x: str(x) + "_train", losses["train"].keys())
+                    )
+                    valid_head_str = ",".join(
+                        map(lambda x: str(x) + "_valid", losses["val"].keys())
+                    )
+                    fi.write(f"iter_num,{train_head_str},{valid_head_str},lr,mfu\n")
+                train_loss_str = ",".join(
+                    map(lambda x: str(x.item()), losses["train"].values())
+                )
+                valid_loss_str = ",".join(
+                    map(lambda x: str(x.item()), losses["val"].values())
+                )
+                fi.write(
+                    f"{iter_num},{train_loss_str},{valid_loss_str},{lr},{running_mfu * 100}\n"
+                )
+            if log_via_wandb:
+                wandb.log({"valloss": losses["val"]}, step=iter_num)
+
+            if val_loss < best_val_loss or always_save_checkpoint:
+                best_val_loss = val_loss
+                if iter_num > 0:
+                    checkpoint = {
+                        "model": raw_model.state_dict(),
+                        "optimizer": optimizer.state_dict(),
+                        "model_args": model_args,
+                        "iter_num": iter_num,
+                        "best_val_loss": best_val_loss,
+                        "config": config,
+                        "modality_registry": modality_registry,
+                    }
+                    if master_process:
+                        print(f"saving checkpoint to {out_dir}")
+                    torch.save(checkpoint, os.path.join(out_dir, "ckpt.pt"))
+        if iter_num == 0 and eval_only:
+            break
+
+        for micro_step in range(gradient_accumulation_steps):
+            if ddp:
+                model.require_backward_grad_sync = (
+                    micro_step == gradient_accumulation_steps - 1
+                )
+            with ctx:
+                logits, loss = model(B["X"], targets=B["Y"])
+            B = tds.process_modes(
+                next(tdl), modality_registry, device, objective=objective
+            )
+            scaler.scale(loss).backward()
+
+        if grad_clip != 0.0:
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        scaler.step(optimizer)
+        scaler.update()
+        optimizer.zero_grad(set_to_none=True)
+
+        t1 = time.time()
+        dt = t1 - t0
+        dts.append(dt)
+        t0 = t1
+        if iter_num % log_interval == 0 and master_process:
+            lossf = loss.item() * gradient_accumulation_steps
+            if local_iter_num >= 5:
+                mfu = raw_model.estimate_mfu(batch_size * gradient_accumulation_steps, dt)
+                running_mfu = mfu if running_mfu == -1.0 else 0.9 * running_mfu + 0.1 * mfu
+            if log_via_wandb:
+                wandb.log({"loss": lossf, "time": dt}, step=iter_num)
+            print(
+                f"iter {iter_num}: loss {lossf:.6f}, time {np.mean(dts) * 1000:.2f}ms, mfu {running_mfu * 100:.2f}%"
+            )
+            dts = []
+
+        iter_num += 1
+        local_iter_num += 1
+
+        if iter_num > max_iters:
+            if log_emissions:
+                emissions = tracker.stop()
+                if master_process:
+                    print(emissions)
+            break
+
+    if ddp:
+        destroy_process_group()
+    if log_via_wandb:
+        wandb.finish()

--- a/src/astropt/local_datasets.py
+++ b/src/astropt/local_datasets.py
@@ -160,9 +160,15 @@ class GalaxyImageDataset(Dataset):
         return patch_spectra, patch_wl
 
     @staticmethod
-    def process_modes(x, modality_registry, device, shuf=False):
+    def process_modes(x, modality_registry, device, shuf=False, objective="ar"):
         """Move all tensor values in dictionary x to the specified device.
-        And split into X and Y according to the modality registry."""
+        And split into X and Y according to the modality registry.
+
+        For the autoregressive objective ("ar") the target is the input shifted
+        by one patch (next-patch prediction). For the masked autoencoder
+        objective ("mae") the model masks patches internally, so X and Y are
+        both the full, unshifted patch sequence.
+        """
         modes = modality_registry.generate_sequence(shuf=shuf)
 
         # Move all tensors to device first
@@ -176,6 +182,9 @@ class GalaxyImageDataset(Dataset):
             X[mode] = x_on_device[mode]
             X[f"{mode}_positions"] = x_on_device[f"{mode}_positions"]
             Y[mode] = x_on_device[mode]
+            if objective == "mae":
+                # MAE reconstructs masked patches in place: full sequence, no shift
+                continue
             if ii == 0:
                 Y[mode] = Y[mode][:, 1:]
             if len(modes) == 1:

--- a/src/astropt/model.py
+++ b/src/astropt/model.py
@@ -148,7 +148,9 @@ class SelfAttention(nn.Module):
         self.dropout = config.dropout
 
         self.attn_type = config.attn_type
-        if self.attn_type == "causal":
+        if self.attn_type in ("causal", "full"):
+            # "causal" attends only to the left (autoregressive); "full" is
+            # bidirectional, as needed for BERT-style masked autoencoding.
             # flash attention make GPU go brrrrr but support is only in PyTorch >= 2.0
             self.flash = hasattr(torch.nn.functional, "scaled_dot_product_attention")
             if not self.flash:
@@ -168,7 +170,7 @@ class SelfAttention(nn.Module):
             self.flex_attention = torch.compile(flex_attention)
         else:
             raise NotImplementedError(
-                "Attention type must be one of 'causal' or 'prefix'. Prefix requires PyTorch >= 2.6."
+                "Attention type must be one of 'causal', 'full', or 'prefix'. Prefix requires PyTorch >= 2.6."
             )
 
     def forward(self, x, block_mask=None):
@@ -188,8 +190,9 @@ class SelfAttention(nn.Module):
             1, 2
         )  # (B, nh, T, hs)
 
-        if self.attn_type == "causal":
-            # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
+        if self.attn_type in ("causal", "full"):
+            is_causal = self.attn_type == "causal"
+            # self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
             if self.flash:
                 # efficient attention using Flash Attention CUDA kernels
                 y = torch.nn.functional.scaled_dot_product_attention(
@@ -198,12 +201,13 @@ class SelfAttention(nn.Module):
                     v,
                     attn_mask=None,
                     dropout_p=self.dropout if self.training else 0,
-                    is_causal=True,
+                    is_causal=is_causal,
                 )
             else:
                 # manual implementation of attention
                 att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
-                att = att.masked_fill(self.bias[:, :, :T, :T] == 0, float("-inf"))
+                if is_causal:
+                    att = att.masked_fill(self.bias[:, :, :T, :T] == 0, float("-inf"))
                 att = F.softmax(att, dim=-1)
                 att = self.attn_dropout(att)
                 y = att @ v  # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
@@ -211,7 +215,7 @@ class SelfAttention(nn.Module):
             y = self.flex_attention(q, k, v, block_mask=block_mask)
         else:
             raise NotImplementedError(
-                "Attention type must be one of 'causal' or 'prefix'. Prefix requires PyTorch >= 2.6."
+                "Attention type must be one of 'causal', 'full', or 'prefix'. Prefix requires PyTorch >= 2.6."
             )
         y = (
             y.transpose(1, 2).contiguous().view(B, T, C)

--- a/src/astropt/model.py
+++ b/src/astropt/model.py
@@ -593,6 +593,8 @@ class GPT(nn.Module):
         attention_mask=None,
     ):
         if self.backbone == "native":
+            if self.config.objective == "mae":
+                return self._forward_mae(inputs, targets)
             return self._forward_native(
                 inputs, targets, prefix_len, target_modality, attention_mask
             )
@@ -602,6 +604,55 @@ class GPT(nn.Module):
             )
         else:
             raise ValueError(f"Unknown backbone type: {self.backbone}")
+
+    def _forward_mae(self, inputs, targets=None):
+        """BERT-style masked-autoencoder forward pass.
+
+        A fraction of patches is replaced by the learnable mask token in the
+        encoder input; the full sequence is processed bidirectionally (with
+        learned positions kept on every token, masked or not), and the masked
+        patches are reconstructed by the per-modality Decoder head. The loss is
+        the reconstruction error over the masked patches only.
+
+        Returns ``(outputs, loss)`` where ``outputs[mod]`` is the full
+        reconstruction and ``outputs[mod + "_mask"]`` is the binary mask
+        (1 = patch was masked) so callers can composite/visualise.
+        """
+        mod = self.modality_registry.names()[0]  # single modality (enforced in __init__)
+        x_patches = inputs[mod]  # (B, N, P)
+        pos = inputs[mod + "_positions"]  # (B, N)
+        B, N, _ = x_patches.shape
+        assert N <= self.config.block_size, (
+            f"Cannot forward sequence of length {N}, block size is only {self.config.block_size}"
+        )
+
+        tok = self.encoders[mod](x_patches)  # (B, N, C)
+        mask = random_token_mask(B, N, self.config.mae_mask_ratio, x_patches.device)
+        # replace masked patch embeddings with the shared mask token
+        tok = torch.where(mask.unsqueeze(-1), self.mask_token.to(tok.dtype), tok)
+
+        x = self.transformer.drop(tok + self.embedders[mod](pos))
+        for block in self.transformer.h:
+            x = block(x)
+        x = self.transformer.ln_f(x)
+        pred = self.decoders[mod](x)  # (B, N, P)
+
+        outputs = {mod: pred, mod + "_mask": mask}
+
+        if targets is not None:
+            target = targets[mod]
+            if self.config.norm_pix_loss:
+                mean = target.mean(dim=-1, keepdim=True)
+                var = target.var(dim=-1, keepdim=True)
+                target = (target - mean) / (var + 1e-6).sqrt()
+            # per-patch reconstruction error, averaged over the masked patches only
+            per_patch = F.huber_loss(pred, target, reduction="none").mean(dim=-1)  # (B, N)
+            loss = (per_patch * mask).sum() / mask.sum()
+            loss = loss * self.modality_registry.get_config(mod).loss_weight
+        else:
+            loss = None
+
+        return outputs, loss
 
     def _forward_native(
         self,

--- a/src/astropt/model.py
+++ b/src/astropt/model.py
@@ -341,8 +341,16 @@ class GPTConfig:
     n_chan: int = 1
     dropout: float = 0.0
     bias: bool = False  # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
-    attn_type: str = "causal"  # causal or prefix
+    attn_type: str = "causal"  # causal, full, or prefix
     tokeniser: str = "aim" # one of "aim" or "affine"
+    # objective: "ar" = autoregressive next-patch prediction (default), "mae" =
+    # BERT-style masked autoencoder (mask tokens flow through a full
+    # bidirectional encoder; masked patches are reconstructed).
+    objective: str = "ar"
+    mae_mask_ratio: float = 0.15  # fraction of patches replaced by the mask token
+    # normalise each target patch before the reconstruction loss (MAE paper).
+    # Defaults False as the image pipeline already per-patch normalises.
+    norm_pix_loss: bool = False
     # LoRA params
     lora_r: int = 0  # rank, 0 disables LoRA
     lora_alpha: float = 2.0

--- a/src/astropt/model.py
+++ b/src/astropt/model.py
@@ -124,6 +124,23 @@ def generate_prefix_lm_mask(prefix_length):
     return prefix_lm_causal_mask
 
 
+def random_token_mask(batch, seq_len, mask_ratio, device):
+    """Per-sample boolean mask for BERT-style masked autoencoding.
+
+    Returns a ``(batch, seq_len)`` bool tensor with ~``mask_ratio`` of positions
+    set True. True positions are replaced by the mask token in the encoder input
+    and reconstructed by the loss. At least one position per sample is masked so
+    the loss is always defined.
+    """
+    mask = torch.rand(batch, seq_len, device=device) < mask_ratio
+    empty = ~mask.any(dim=1)
+    if empty.any():
+        rows = empty.nonzero(as_tuple=True)[0]
+        cols = torch.randint(seq_len, (rows.numel(),), device=device)
+        mask[rows, cols] = True
+    return mask
+
+
 class SelfAttention(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -374,6 +391,18 @@ class GPT(nn.Module):
         self.modality_registry = modality_registry
         self.backbone = config.backbone
 
+        if config.objective == "mae":
+            if config.backbone != "native":
+                raise ValueError("MAE objective is only supported with the native backbone")
+            if config.attn_type == "causal":
+                raise ValueError(
+                    "MAE needs bidirectional attention; set attn_type='full' (not 'causal')"
+                )
+            if len(self.modality_registry.names()) != 1:
+                raise NotImplementedError(
+                    "MAE objective currently supports a single modality only"
+                )
+
         if self.backbone == "native":
             self._init_native_backbone(config)
         elif self.backbone == "llm":
@@ -446,6 +475,13 @@ class GPT(nn.Module):
         self.encoders = nn.ModuleDict(encoders)
         self.decoders = nn.ModuleDict(decoders)
         self.embedders = nn.ModuleDict(embedders)
+
+        if config.objective == "mae":
+            # learnable token that replaces masked patches in the encoder input
+            # (BERT-style). The per-modality Decoder doubles as the reconstruction
+            # head, so no separate decoder transformer is needed.
+            self.mask_token = nn.Parameter(torch.zeros(1, 1, config.n_embd))
+            torch.nn.init.normal_(self.mask_token, std=0.02)
 
         # with weight tying when using torch.compile() some warnings get generated:
         # "UserWarning: functional_call was passed multiple values for tied weights.


### PR DESCRIPTION
## BERT-style masked-autoencoder (MAE) pretraining

Adds a config-gated **BERT-style** MAE objective alongside the default autoregressive one. A fraction of image patches is replaced by a learnable mask token, the **full** patch sequence is processed by the bidirectional encoder, and the masked patches are reconstructed by the per-modality decoder head. The AR path is unchanged (`objective="ar"` default).

This is the BERT/SimMIM formulation (mask tokens flow through the encoder), not the image-MAE asymmetric encoder/decoder. It uses AstroPT's existing **learned absolute (BERT-style) positional embeddings** — no new positional code.

### Commits
- `feat(model)`: bidirectional `"full"` attention type
- `feat(model)`: MAE config fields (`objective`, `mae_mask_ratio`, `norm_pix_loss`)
- `feat(model)`: mask token + `random_token_mask` + construction guards
- `feat(model)`: BERT-style `_forward_mae` (mask → full encoder → reconstruct masked; Huber loss on masked patches only)
- `feat(data)`: MAE branch in `process_modes` (full, unshifted sequence)
- `feat(train)`: `scripts/train_mae.py` (+ `config/astropt_mae.py`)
- `docs`: README section

### Testing
CPU eager smoke tests (mask ratio, gradients to mask token, loss over masked patches only, eval-mode, AR unchanged) and a GPU forward/backward on a 123M model (flash attention, bf16).

### Notes
- Single image modality (enforced); AR `generate()`/sampler are not meaningful under MAE.
- `mae_mask_ratio` defaults to 0.15 (BERT) in the model; the example config uses 0.5 (image MLM, SimMIM-style).
- One of three independent PRs (this, DDP stream sharding, step checkpointing). `train_mae.py` mirrors the current `train.py`, so it does not yet include sharding/checkpointing — those land via their own PRs / the planned train-loop refactor.
