### PR TITLE
Wire the tokeniser choice (aim/affine) into model_args

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -291,6 +291,7 @@ if __name__ == "__main__":
         dropout=dropout,
         modalities=modalities,
         attn_type=attn_type,
+        tokeniser=tokeniser,
     )
 
     if init_from == "scratch":


### PR DESCRIPTION
The `tokeniser` config var ("aim" MLP vs "affine" single-linear/ViT-style patch embedding) was defined in `train.py` but never passed into `model_args`, so `GPTConfig` always used the "aim" default and `--tokeniser=affine` silently did nothing. This passes it through so the affine embedding is actually selectable.

Verified: `tokeniser=aim` builds the 2-layer MLP patch encoder, `tokeniser=affine` builds the single linear one; both train. One-line change; the model already handles both in `Encoder`/`Decoder`.

Enables a clean aim-vs-affine tokeniser sweep.