### PR TITLE
Reproducible streaming data order across runs (fixed data_seed + pinned num_workers)

### DIFF
--- a/config/pythia-like/ar_affine_001M.py
+++ b/config/pythia-like/ar_affine_001M.py
@@ -27,7 +27,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/ar_affine_021M.py
+++ b/config/pythia-like/ar_affine_021M.py
@@ -27,7 +27,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/ar_affine_100M.py
+++ b/config/pythia-like/ar_affine_100M.py
@@ -27,7 +27,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/ar_aim_001M.py
+++ b/config/pythia-like/ar_aim_001M.py
@@ -27,7 +27,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/ar_aim_021M.py
+++ b/config/pythia-like/ar_aim_021M.py
@@ -27,7 +27,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/ar_aim_100M.py
+++ b/config/pythia-like/ar_aim_100M.py
@@ -27,7 +27,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/mae_affine_001M.py
+++ b/config/pythia-like/mae_affine_001M.py
@@ -29,7 +29,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/mae_affine_021M.py
+++ b/config/pythia-like/mae_affine_021M.py
@@ -29,7 +29,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/mae_affine_100M.py
+++ b/config/pythia-like/mae_affine_100M.py
@@ -29,7 +29,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/mae_aim_001M.py
+++ b/config/pythia-like/mae_aim_001M.py
@@ -29,7 +29,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/mae_aim_021M.py
+++ b/config/pythia-like/mae_aim_021M.py
@@ -29,7 +29,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/config/pythia-like/mae_aim_100M.py
+++ b/config/pythia-like/mae_aim_100M.py
@@ -29,7 +29,7 @@ gradient_accumulation_steps = 5 * 8
 max_iters = 30000
 lr_decay_iters = 27000 * 1.1
 weight_decay = 1e-1
-num_workers = 32
+num_workers = 8  # pinned + identical across all configs for reproducible data order
 
 # --- 64 log-spaced checkpoints, for probing physics emergence across training ---
 # (pure log over 30k steps yields ~57 *distinct* steps due to early integer

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -111,6 +111,10 @@ if __name__ == "__main__":
     use_hf = True  # use the huggingface dataset version of our galz
     stream_hf_dataset = True  # stream the galaxies from huggingface
     shuffle_buffer_size = 1000  # buffered shuffle size for the streaming train set
+    # Seed for the streaming-data shuffle. Fixed (and independent of the per-rank model
+    # seed) so every run sees the IDENTICAL global example order regardless of GPU count
+    # -- important when comparing configs in a scaling study.
+    data_seed = 1337
     # data
     gradient_accumulation_steps = 5 * 8  # used to simulate larger batch sizes
     batch_size = 16  # if gradient_accumulation_steps > 1, this is the micro-batch size
@@ -294,9 +298,17 @@ if __name__ == "__main__":
         )
         vds_hf = vds_hf.remove_columns("image")
 
-        # Shard the stream across DDP ranks so each GPU sees disjoint data.
-        # Without this every rank iterates the identical stream, so e.g. 8 GPUs
-        # would all train on the same galaxies (no data-throughput scaling).
+        # Shuffle the FULL stream with a fixed data_seed BEFORE sharding, so the global
+        # example order depends only on data_seed -- not on the GPU count or the per-rank
+        # model seed. Every config therefore trains on the identical example order, and
+        # each rank below takes a deterministic, disjoint slice of that one canonical order.
+        if stream_hf_dataset:
+            tds_hf = tds_hf.shuffle(
+                seed=data_seed, buffer_size=shuffle_buffer_size
+            )
+        # Shard the stream across DDP ranks so each GPU sees disjoint data. Without this
+        # every rank iterates the identical stream, so e.g. 8 GPUs would all train on the
+        # same galaxies (no data-throughput scaling).
         if ddp:
             from datasets.distributed import split_dataset_by_node
 
@@ -305,11 +317,6 @@ if __name__ == "__main__":
             )
             vds_hf = split_dataset_by_node(
                 vds_hf, rank=ddp_rank, world_size=ddp_world_size
-            )
-        # Buffered shuffle of the (otherwise in-order) streaming training set.
-        if stream_hf_dataset:
-            tds_hf = tds_hf.shuffle(
-                seed=1337 + seed_offset, buffer_size=shuffle_buffer_size
             )
 
     tdl = iter(


### PR DESCRIPTION
Make the streaming training data appear in the **same example order for every run/config**, so a scaling study compares model/objective on identical data.

**1. `scripts/train.py` — fixed `data_seed`, shuffle before shard.**
The stream shuffled *after* node-sharding with a *rank-dependent* seed (`1337 + seed_offset`), so the global order depended on GPU count and the model seed. Now it shuffles the full stream with a fixed `data_seed = 1337` *before* sharding; each rank takes a deterministic disjoint slice. Model/DDP seeding unchanged; single-GPU behavior unchanged.

**2. `config/pythia-like/*.py` — pin `num_workers` 32 → 8.**
Byte-identical batch order also needs the same `num_workers` (DataLoader worker interleaving sets the order). 32/rank × 4 ranks ≈ 128 concurrent HF range-requests on the 764 GB stream → HTTP 429, forcing per-run overrides that break reproducibility. A fixed `8` (~32 streams/node) is 429-safe and identical across all 12 configs.

(The one-epoch `max_iters` change is split out into #71.)

