### PR TITLE
Set scaling-study configs to exactly one epoch

### DIFF
--- a/config/pythia-like/ar_affine_001M.py
+++ b/config/pythia-like/ar_affine_001M.py
@@ -24,8 +24,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/ar_affine_021M.py
+++ b/config/pythia-like/ar_affine_021M.py
@@ -24,8 +24,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/ar_affine_100M.py
+++ b/config/pythia-like/ar_affine_100M.py
@@ -24,8 +24,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/ar_aim_001M.py
+++ b/config/pythia-like/ar_aim_001M.py
@@ -24,8 +24,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/ar_aim_021M.py
+++ b/config/pythia-like/ar_aim_021M.py
@@ -24,8 +24,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/ar_aim_100M.py
+++ b/config/pythia-like/ar_aim_100M.py
@@ -24,8 +24,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/mae_affine_001M.py
+++ b/config/pythia-like/mae_affine_001M.py
@@ -26,8 +26,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/mae_affine_021M.py
+++ b/config/pythia-like/mae_affine_021M.py
@@ -26,8 +26,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/mae_affine_100M.py
+++ b/config/pythia-like/mae_affine_100M.py
@@ -26,8 +26,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/mae_aim_001M.py
+++ b/config/pythia-like/mae_aim_001M.py
@@ -26,8 +26,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/mae_aim_021M.py
+++ b/config/pythia-like/mae_aim_021M.py
@@ -26,8 +26,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 

--- a/config/pythia-like/mae_aim_100M.py
+++ b/config/pythia-like/mae_aim_100M.py
@@ -26,8 +26,8 @@ min_lr = learning_rate / 10
 # --- fixed across all 12 runs (only size/objective/tokeniser/LR vary) ---
 batch_size = 16
 gradient_accumulation_steps = 5 * 8
-max_iters = 30000
-lr_decay_iters = 27000 * 1.1
+max_iters = 13241  # exactly one pass over the 8,474,566-galaxy train set at eff. batch 640
+lr_decay_iters = 13241.0  # decay LR to min over the single epoch
 weight_decay = 1e-1
 num_workers = 32
 


### PR DESCRIPTION
`max_iters = 30000` in the `config/pythia-like` configs was an inherited nanoGPT placeholder, not derived from the dataset. At effective batch 640 that's 19.2M presentations = **~2.27 passes** over the 8,474,566-galaxy `Smith42/galaxies` train split.

This sets `max_iters = 13241 = floor(8,474,566 / 640)` — one pass over the train set (~2.17B image-patch tokens, ≈ Chinchilla-optimal for the 100M run) — and shrinks `lr_decay_iters` to match so the cosine LR fully decays to `min_lr` by the end of the run rather than stopping mid-decay.

(Note: 13241 is one pass *minus* a 326-example remainder, since 8,474,566 isn't divisible by the effective batch; truly exact one-pass coverage under DDP needs len-aware sampling, which is a separate change.)

