### PR TITLE
Exact one-epoch training from local data (padding-free distributed sampler)

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -111,6 +111,13 @@ if __name__ == "__main__":
     use_hf = True  # use the huggingface dataset version of our galz
     stream_hf_dataset = True  # stream the galaxies from huggingface
     shuffle_buffer_size = 1000  # buffered shuffle size for the streaming train set
+    # Exact one-epoch mode. If data_dir is set, the galaxies are loaded map-style from
+    # local parquet (download them once -- streaming cannot do an exact, length-aware
+    # epoch) and trained for exactly one pass via astropt.exact_epoch: every example is
+    # seen exactly once, no drop, no duplicate. data_seed fixes the sampler order (and the
+    # streaming shuffle) so every config sees the identical example order.
+    data_dir = ""
+    data_seed = 1337
     # data
     gradient_accumulation_steps = 5 * 8  # used to simulate larger batch sizes
     batch_size = 16  # if gradient_accumulation_steps > 1, this is the micro-batch size
@@ -269,7 +276,69 @@ if __name__ == "__main__":
         modality_registry=modality_registry,
     )
 
-    if use_hf:
+    exact_mode = bool(data_dir)
+    if exact_mode:
+        # Exact one-epoch: load the galaxies map-style from local parquet and shard them
+        # with the padding-free ExactDistributedSampler (one pass = every example once).
+        import glob as _glob
+
+        from datasets import load_dataset
+
+        from astropt.exact_epoch import ExactDistributedSampler
+
+        tr_files = sorted(
+            _glob.glob(os.path.join(data_dir, "**", "train-*.parquet"), recursive=True)
+        )
+        va_files = sorted(
+            _glob.glob(os.path.join(data_dir, "**", "test-*.parquet"), recursive=True)
+        )
+        if not tr_files:
+            raise FileNotFoundError(f"no train-*.parquet found under data_dir={data_dir!r}")
+        train_hf = load_dataset(
+            "parquet", data_files=tr_files, split="train"
+        ).select_columns("image")
+        val_hf = load_dataset(
+            "parquet", data_files=va_files, split="train"
+        ).select_columns("image")
+        _proc1 = partial(process_galaxy_wrapper, func=tds.process_galaxy)
+
+        class _LocalGalaxies(torch.utils.data.Dataset):
+            def __init__(self, hf):
+                self.hf = hf
+
+            def __len__(self):
+                return len(self.hf)
+
+            def __getitem__(self, i):
+                return _proc1(self.hf[i])
+
+        train_ds_local = _LocalGalaxies(train_hf)
+        val_ds_local = _LocalGalaxies(val_hf)
+        train_sampler = ExactDistributedSampler(
+            len(train_ds_local), ddp_world_size, ddp_rank if ddp else 0, seed=data_seed
+        )
+        tdl = DataLoader(
+            train_ds_local,
+            batch_size=batch_size,
+            sampler=train_sampler,
+            num_workers=num_workers,
+            pin_memory=True,
+            drop_last=False,
+        )
+        eval_vdl = DataLoader(
+            val_ds_local,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            pin_memory=True,
+            drop_last=True,
+        )
+        if master_process:
+            print(
+                f"exact one-epoch: {len(train_ds_local):,} train galaxies "
+                f"({len(train_sampler):,} on this rank)"
+            )
+    elif use_hf:
         from datasets import load_dataset
 
         tds_hf = load_dataset(
@@ -311,23 +380,33 @@ if __name__ == "__main__":
             tds_hf = tds_hf.shuffle(
                 seed=1337 + seed_offset, buffer_size=shuffle_buffer_size
             )
-
-    tdl = iter(
-        DataLoader(
-            tds_hf if use_hf else tds,
-            batch_size=batch_size,
-            num_workers=num_workers,
-            pin_memory=True,
+        tdl = iter(
+            DataLoader(
+                tds_hf,
+                batch_size=batch_size,
+                num_workers=num_workers,
+                pin_memory=True,
+            )
         )
-    )
-    vdl = iter(
-        DataLoader(
-            vds_hf if use_hf else vds,
-            batch_size=batch_size,
-            num_workers=num_workers,
-            pin_memory=True,
+        vdl = iter(
+            DataLoader(
+                vds_hf,
+                batch_size=batch_size,
+                num_workers=num_workers,
+                pin_memory=True,
+            )
         )
-    )
+    else:
+        tdl = iter(
+            DataLoader(
+                tds, batch_size=batch_size, num_workers=num_workers, pin_memory=True
+            )
+        )
+        vdl = iter(
+            DataLoader(
+                vds, batch_size=batch_size, num_workers=num_workers, pin_memory=True
+            )
+        )
 
     # init these up here, can override if init_from='resume' (i.e. from a checkpoint)
     iter_num = 0
@@ -570,9 +649,10 @@ if __name__ == "__main__":
     # training loop
     if master_process:
         print("starting training...")
-    B = tds.process_modes(
-        next(tdl), modality_registry, device, objective=objective
-    )  # fetch the very first batch
+    if not exact_mode:
+        B = tds.process_modes(
+            next(tdl), modality_registry, device, objective=objective
+        )  # fetch the very first batch
     t0 = time.time()
     dts = []
     local_iter_num = 0  # number of iterations in the lifetime of this process
@@ -623,7 +703,77 @@ if __name__ == "__main__":
             on_csv_write="update",
         )
         tracker.start()
-    while True:
+
+    if exact_mode:
+        from astropt.exact_epoch import one_epoch_loop
+
+        _mod0 = modality_registry.names()[0]
+
+        def _process_exact(raw):
+            return tds.process_modes(raw, modality_registry, device, objective=objective)
+
+        def _on_checkpoint_exact(it):
+            save_checkpoint(f"{it:06d}_ckpt.pt")
+
+        @torch.no_grad()
+        def _on_eval_exact(it):
+            global best_val_loss
+            model.eval()
+            vlosses = []
+            ev = iter(eval_vdl)
+            for _ in range(eval_iters):
+                try:
+                    raw = next(ev)
+                except StopIteration:
+                    break
+                Bv = _process_exact(raw)
+                with ctx:
+                    _, vl = model(Bv["X"], targets=Bv["Y"])
+                vlosses.append(vl.item())
+            model.train()
+            vloss = float(np.mean(vlosses)) if vlosses else float("nan")
+            print(f"iter {it}: val loss {vloss:.4f}")
+            with open(os.path.join(out_dir, "loss.txt"), "a") as fi:
+                fi.write(f"{it},{vloss}\n")
+            if it > 0 and vloss < best_val_loss:
+                best_val_loss = vloss
+                save_checkpoint("ckpt.pt")
+
+        iter_num, examples_seen = one_epoch_loop(
+            model=model,
+            loader=tdl,
+            optimizer=optimizer,
+            scaler=scaler,
+            ctx=ctx,
+            process_batch=_process_exact,
+            grad_accum_per_rank=gradient_accumulation_steps,
+            grad_clip=grad_clip,
+            get_lr=(get_lr if decay_lr else (lambda it: learning_rate)),
+            count_examples=lambda B: B["X"][_mod0].shape[0],
+            log_interval=log_interval,
+            eval_interval=eval_interval,
+            checkpoint_iters=checkpoint_iters,
+            on_eval=_on_eval_exact,
+            on_checkpoint=_on_checkpoint_exact,
+            master=master_process,
+            start_iter=iter_num,
+        )
+        if master_process:
+            save_checkpoint(f"{iter_num:06d}_ckpt.pt")
+        _seen = torch.tensor([examples_seen], device=device)
+        if ddp:
+            torch.distributed.all_reduce(_seen)
+        if master_process:
+            total = int(_seen.item())
+            print(
+                f"exact one-epoch done at iter {iter_num}: saw {total:,} examples "
+                f"(dataset has {len(train_ds_local):,})"
+            )
+            assert total == len(train_ds_local), (
+                f"exact-epoch coverage mismatch: {total} != {len(train_ds_local)}"
+            )
+
+    while not exact_mode:
         # determine and set the learning rate for this iteration
         lr = get_lr(iter_num) if decay_lr else learning_rate
         for param_group in optimizer.param_groups:

--- a/src/astropt/exact_epoch.py
+++ b/src/astropt/exact_epoch.py
@@ -1,0 +1,220 @@
+"""
+Exact one-epoch data loading for AstroPT.
+
+Streaming a HF dataset with `split_dataset_by_node` + a buffered shuffle gives an
+example order that depends on the GPU count and the DataLoader worker count, and it
+cannot guarantee "every example exactly once" -- the standard distributed samplers
+either drop the tail or pad it with duplicates when ``len(dataset) % world_size != 0``.
+
+For a scaling study where each run must train on the IDENTICAL data, exactly once,
+we instead use a local map-style dataset and the sampler below.
+
+``ExactDistributedSampler`` partitions ``range(dataset_len)`` across ranks with NO
+padding and NO dropping: a single shared shuffle (seeded only by ``seed``) is sliced
+strided, so rank ``r`` owns ``indices[r::world_size]``. Properties:
+
+* **Exact** -- the union of all ranks is exactly ``{0, ..., dataset_len-1}``; per-rank
+  counts differ by at most one, so one epoch sees every example exactly once.
+* **Reproducible** -- the order depends only on ``seed`` (and ``dataset_len``), so every
+  config that shares ``seed`` trains on the identical global order.
+* **Worker-independent** -- the sampler fixes the index order; DataLoader workers only
+  fetch in parallel, they do not reorder. So ``num_workers`` no longer affects the order.
+
+With micro-batch ``b`` and per-rank accumulation ``a``, every rank runs exactly
+``ceil(ceil(n_r / b) / a)`` optimizer steps. For the AstroPT galaxies set
+(N = 8,474,566) at b=16, total grad-accum 40 and world sizes {1,2,4,8}, that is 13242
+steps on *every* rank -- balanced, so DDP needs no Join; only the final accumulation
+step is short. See ``planned_steps`` / the ``__main__`` self-test below.
+"""
+
+import math
+
+import numpy as np
+import torch
+from torch.utils.data import Sampler
+
+
+class ExactDistributedSampler(Sampler):
+    """Strided, padding-free, drop-free partition of ``range(dataset_len)`` across ranks.
+
+    Args:
+        dataset_len: number of examples in the (map-style) dataset.
+        num_replicas: world size (number of DDP ranks).
+        rank: this process's rank in ``[0, num_replicas)``.
+        seed: shuffle seed -- keep it fixed across configs for identical ordering.
+        shuffle: shuffle before partitioning (True for training).
+    """
+
+    def __init__(self, dataset_len, num_replicas, rank, seed=1337, shuffle=True):
+        if not 0 <= rank < num_replicas:
+            raise ValueError(f"rank {rank} out of range for num_replicas {num_replicas}")
+        self.dataset_len = int(dataset_len)
+        self.num_replicas = int(num_replicas)
+        self.rank = int(rank)
+        self.seed = int(seed)
+        self.shuffle = bool(shuffle)
+
+    def _indices(self):
+        idx = np.arange(self.dataset_len)
+        if self.shuffle:
+            np.random.default_rng(self.seed).shuffle(idx)
+        return idx[self.rank :: self.num_replicas]
+
+    def __iter__(self):
+        return iter(self._indices().tolist())
+
+    def __len__(self):
+        # number of indices i in [0, dataset_len) with i % num_replicas == rank
+        return len(range(self.rank, self.dataset_len, self.num_replicas))
+
+
+def planned_steps(dataset_len, num_replicas, micro_batch, grad_accum):
+    """Optimizer steps each rank will run for one exact epoch, as a list (one per rank).
+
+    ``grad_accum`` is the GLOBAL accumulation (it is split across ranks). All entries are
+    equal when the partition balances; if they are NOT all equal, plain DDP would hang and
+    you would need the Join context manager -- the training loop should assert on this.
+    """
+    if grad_accum % num_replicas != 0:
+        raise ValueError(f"grad_accum {grad_accum} not divisible by num_replicas {num_replicas}")
+    per_rank_accum = grad_accum // num_replicas
+    steps = []
+    for r in range(num_replicas):
+        n_r = len(range(r, dataset_len, num_replicas))
+        micro = math.ceil(n_r / micro_batch)
+        steps.append(math.ceil(micro / per_rank_accum))
+    return steps
+
+
+def one_epoch_loop(
+    *,
+    model,
+    loader,
+    optimizer,
+    scaler,
+    ctx,
+    process_batch,
+    grad_accum_per_rank,
+    grad_clip,
+    get_lr,
+    count_examples,
+    log_interval=100,
+    eval_interval=None,
+    checkpoint_iters=(),
+    on_eval=None,
+    on_checkpoint=None,
+    master=True,
+    start_iter=0,
+    log=print,
+):
+    """Run exactly one pass over ``loader`` (which must use an ``ExactDistributedSampler``).
+
+    An optimizer step is taken every ``grad_accum_per_rank`` micro-batches; the final step
+    of the epoch is short (fewer micro-batches) but -- because the exact partition gives
+    every rank the SAME micro-batch count -- it is short by the same amount on every rank,
+    so the per-step gradient all-reduce count stays balanced and DDP needs no Join.
+
+    Gradients are synced on every backward (no ``no_sync``): all-reduce is linear, so this
+    is numerically identical to accumulate-then-sync, and it keeps the short final step
+    correct. Returns ``(iter_num, examples_seen)``; assert the all-reduced ``examples_seen``
+    equals ``len(dataset)`` to prove exact coverage.
+    """
+    it = iter(loader)
+    for _ in range(start_iter * grad_accum_per_rank):  # resume: skip consumed micro-batches
+        if next(it, None) is None:
+            break
+    iter_num = start_iter
+    seen = 0
+    last_loss = float("nan")
+    while True:
+        lr = get_lr(iter_num)
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr
+        if master and on_eval and eval_interval and iter_num % eval_interval == 0:
+            on_eval(iter_num)
+        if master and on_checkpoint and iter_num in checkpoint_iters:
+            on_checkpoint(iter_num)
+        optimizer.zero_grad(set_to_none=True)
+        micro = 0
+        for _ in range(grad_accum_per_rank):
+            try:
+                raw = next(it)
+            except StopIteration:
+                break
+            B = process_batch(raw)
+            seen += count_examples(B)
+            with ctx:
+                _, loss = model(B["X"], targets=B["Y"])
+            scaler.scale(loss / grad_accum_per_rank).backward()
+            last_loss = loss.item()
+            micro += 1
+        if micro == 0:  # loader exhausted exactly at a step boundary -> epoch done
+            break
+        if grad_clip and grad_clip != 0.0:
+            scaler.unscale_(optimizer)
+            torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        scaler.step(optimizer)
+        scaler.update()
+        iter_num += 1
+        if master and log_interval and iter_num % log_interval == 0:
+            log(f"iter {iter_num}: loss {last_loss * grad_accum_per_rank:.4f} lr {lr:.2e}")
+    return iter_num, seen
+
+
+if __name__ == "__main__":
+    # Self-test: the partition is exact (covers every index once) and step-balanced.
+    def _check(N, W, b, A):
+        seen = []
+        for r in range(W):
+            seen.extend(ExactDistributedSampler(N, W, r, seed=1337)._indices().tolist())
+        assert sorted(seen) == list(range(N)), f"partition not exact for N={N} W={W}"
+        steps = planned_steps(N, W, b, A)
+        balanced = len(set(steps)) == 1
+        print(f"N={N:>9} W={W} b={b} A={A}: exact=True steps={steps[0]} balanced={balanced}")
+        return balanced
+
+    ok = True
+    for W in (1, 2, 4, 8):
+        ok &= _check(8_474_566, W, 16, 40)  # the AstroPT galaxies train split
+    for N in (1000, 1001, 1024, 999_983):   # assorted sizes incl. a prime
+        for W in (1, 2, 3, 4):
+            seen = []
+            for r in range(W):
+                seen.extend(ExactDistributedSampler(N, W, r)._indices().tolist())
+            assert sorted(seen) == list(range(N)), f"partition not exact for N={N} W={W}"
+    print("exact partition verified for all cases; galaxies set step-balanced:", ok)
+
+    # CPU control-flow test of one_epoch_loop: it must consume EXACTLY N examples and run
+    # the expected number of optimizer steps, including a short final accumulation step.
+    from contextlib import nullcontext
+
+    from torch.utils.data import DataLoader, Dataset
+
+    class _Toy(Dataset):
+        def __init__(self, n): self.n = n
+        def __len__(self): return self.n
+        def __getitem__(self, i): return torch.tensor([float(i)])
+
+    class _ToyModel(torch.nn.Module):
+        def __init__(self): super().__init__(); self.w = torch.nn.Parameter(torch.zeros(1))
+        def forward(self, X, targets=None): return None, (self.w * X).sum()
+
+    for N, b, accpr in [(1000, 4, 3), (8474566 // 4, 16, 10)]:  # 2nd = one W=4 rank slice
+        ds = _Toy(N)
+        loader = DataLoader(ds, batch_size=b,
+                            sampler=ExactDistributedSampler(N, 1, 0, seed=1337),
+                            drop_last=False)
+        model = _ToyModel()
+        opt = torch.optim.SGD(model.parameters(), lr=0.0)
+        steps, seen = one_epoch_loop(
+            model=model, loader=loader, optimizer=opt,
+            scaler=torch.amp.GradScaler("cpu", enabled=False), ctx=nullcontext(),
+            process_batch=lambda raw: {"X": raw, "Y": raw},
+            grad_accum_per_rank=accpr, grad_clip=0.0, get_lr=lambda it: 0.0,
+            count_examples=lambda B: B["X"].shape[0], log_interval=0, master=False,
+        )
+        expected_steps = math.ceil(math.ceil(N / b) / accpr)
+        assert seen == N, f"coverage {seen} != {N}"
+        assert steps == expected_steps, f"steps {steps} != {expected_steps}"
+        print(f"one_epoch_loop: N={N:>9} b={b} accpr={accpr} -> seen={seen} steps={steps} (exact)")
+    print("one_epoch_loop consumes exactly N with the expected step count.")


### PR DESCRIPTION
For scaling studies that must train every config on the **identical data, every example exactly once**. Streaming + `split_dataset_by_node` + buffered shuffle can't do that — the order depends on GPU/worker count, and the standard distributed samplers either drop the tail or pad it with duplicates when `len % world_size != 0`.

### `src/astropt/exact_epoch.py` (new, unit-tested)
- **`ExactDistributedSampler`** — partitions `range(N)` across ranks with **no padding, no dropping**: a single seeded shuffle, sliced strided (`idx[rank::world_size]`). Exact coverage, reproducible (depends only on `data_seed`), and **independent of `num_workers`** (the sampler fixes the order; workers only fetch).
- **`one_epoch_loop`** — consumes the loader exactly once; an optimizer step every `grad_accum_per_rank` micro-batches with a short final step. The exact partition gives **every rank the same micro-batch count**, so the short final step is identical across ranks → the per-step all-reduce count stays balanced and **DDP needs no `Join`**. Gradients sync every backward (all-reduce is linear ⇒ identical to accumulate-then-sync).
- **Self-tests** (`python -m astropt.exact_epoch`): exact partition for many sizes incl. a prime; the loop consumes exactly N with the expected step count. For the galaxies set (N=8,474,566), W∈{1,2,4,8} all balance to **13,242** steps.

### `scripts/train.py`
When `data_dir` is set: load the galaxies map-style from local parquet, shard with `ExactDistributedSampler`, run `one_epoch_loop`, and **assert the all-reduced example count == dataset size** — a run self-proves exact coverage or fails loudly. Streaming path unchanged.

### Notes
- Adds `data_seed` (also introduced by the data-order PR #70 — trivial overlap to resolve on merge; the streaming-shuffle block is also restructured into `if exact / elif use_hf / else`).
- The DDP path is arithmetically balanced and self-asserting, but I could **not run it multi-GPU** — it needs a smoke test on a real 4-GPU node before relying on it.

